### PR TITLE
Trust in traefik forwarded headers

### DIFF
--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -18,6 +18,9 @@ services:
       - --providers.docker.exposedbydefault=false
       # Enable Docker Swarm mode
       - --providers.docker.swarmmode
+      # Trust the forwarded headers information (X-Forwarded-*) from the public Traefik
+      - --entryPoints.web.address=:80
+      - --entryPoints.web.forwardedHeaders.insecure
       # Enable the access log, with HTTP requests
       - --accesslog
       # Enable the Traefik log, for configurations and errors


### PR DESCRIPTION
FastAPI application doesn't redirect to HTTPS because of proxy not forwarding X-Forwarded-* headers from public Traefik proxy.